### PR TITLE
autocomplete cep for delivery point

### DIFF
--- a/app/controllers/delivery_points_controller.rb
+++ b/app/controllers/delivery_points_controller.rb
@@ -34,7 +34,7 @@ class DeliveryPointsController < ApplicationController
 	private
 
 	def params_delivery_point
-		params.require(:delivery_point).permit(:name, :address, :cep, :contact, :comment)
+		params.require(:delivery_point).permit(:name, :uf,:rua, :cidade, :bairro, :numero, :complemento, :cep, :contact, :comment)
 	end
 
 	def find_delivery_point

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -51,6 +51,7 @@ document.addEventListener('turbolinks:load', () => {
     getCEP();
   }
 
-
-  
+  if (document.getElementById("new_delivery_point")) {
+    getCEP();
+  }
 });

--- a/app/javascript/packs/cep_search.js
+++ b/app/javascript/packs/cep_search.js
@@ -1,5 +1,5 @@
 const getCEP = () => {
-  $("#company_cep").blur(function () {
+  $("#cep").blur(function () {
     var cep = $(this).val().replace(/\D/g, "");
 
     if (cep != "") {
@@ -10,22 +10,18 @@ const getCEP = () => {
           "https://viacep.com.br/ws/" + cep + "/json/?callback=?",
           function (dados) {
             if (!("erro" in dados)) {
-              $("#company_rua").val(dados.logradouro);
-              $("#company_bairro").val(dados.bairro);
-              $("#company_cidade").val(dados.localidade);
-              $("#company_uf").val(dados.uf);
+              $("#rua").val(dados.logradouro);
+              $("#bairro").val(dados.bairro);
+              $("#cidade").val(dados.localidade);
+              $("#uf").val(dados.uf);              
             } else {
-              limpa_formulário_cep();
               alert("CEP não encontrado.");
             }
           }
         );
       } else {
-        limpa_formulário_cep();
         alert("Formato de CEP inválido.");
       }
-    } else {
-      limpa_formulário_cep();
     }
   });
 };

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -14,31 +14,31 @@
         </div>
         <div class="d-flex d-flex justify-content-center">
             <div class="form-item row-with-3">
-                <%= f.input :cep %>
+                <%= f.input :cep, :input_html => {:id => "cep"} %> 
             </div>
             <div class="form-item row-with-3">
-                <%= f.input :uf %>
+                <%= f.input :uf, :input_html => {:id => "uf"} %> 
             </div>
             <div class="form-item row-with-3">
-                <%= f.input :cidade %>
+                <%= f.input :cidade, :input_html => {:id => "cidade"} %> 
             </div>
         </div>
         <div class="d-flex d-flex justify-content-center">
         </div>
         <div class="d-flex d-flex justify-content-center">
             <div class="form-item row-with-2">
-                <%= f.input :bairro %>
+                <%= f.input :bairro, :input_html => {:id => "bairro"} %> 
             </div>
             <div class="form-item row-with-2">
-                <%= f.input :rua %>
+                <%= f.input :rua, :input_html => {:id => "rua"} %> 
             </div>
         </div>
         <div class="d-flex d-flex justify-content-center">
             <div class="form-item row-with-2">
-                <%= f.input :numero %>
+                <%= f.input :numero, :input_html => {:id => "numero"} %> 
             </div>
             <div class="form-item row-with-2">
-                <%= f.input :complemento %>
+                <%= f.input :complemento, :input_html => {:id => "complemento"} %> 
             </div>
         </div>
 

--- a/app/views/fabric_to_carts/_delivery_point_form.html.erb
+++ b/app/views/fabric_to_carts/_delivery_point_form.html.erb
@@ -1,8 +1,43 @@
 <%= simple_form_for delivery_point, remote: true do |f| %>
-	<%= f.input :name %>
-	<%= f.input :address %>
-	<%= f.input :cep %>
-	<%= f.input :contact %>
-	<%= f.input :comment %>
-	<%= f.submit class: "btn btn-success" %>
+<div class="form-item">
+    <%= f.input :name,label: "Nome" %>
+</div>
+<div class="d-flex d-flex justify-content-center">
+    <div class="form-item row-with-3">
+        <%= f.input :cep, :input_html => {:id => "cep"} %>
+    </div>
+    <div class="form-item row-with-3">
+        <%= f.input :uf, :input_html => {:id => "uf"} %>
+    </div>
+    <div class="form-item row-with-3">
+        <%= f.input :cidade, :input_html => {:id => "cidade"} %>
+    </div>
+</div>
+<div class="d-flex d-flex justify-content-center">
+</div>
+<div class="d-flex d-flex justify-content-center">
+    <div class="form-item row-with-2">
+        <%= f.input :bairro, :input_html => {:id => "bairro"} %>
+    </div>
+    <div class="form-item row-with-2">
+        <%= f.input :rua, :input_html => {:id => "rua"} %>
+    </div>
+</div>
+<div class="d-flex d-flex justify-content-center">
+    <div class="form-item row-with-2">
+        <%= f.input :numero, :input_html => {:id => "numero"} %>
+    </div>
+    <div class="form-item row-with-2">
+        <%= f.input :complemento, :input_html => {:id => "complemento"} %>
+    </div>
+</div>
+<div class="form-item">
+    <%= f.input :contact,label: "Contato" %>
+</div>
+<div class="form-item">
+    <%= f.input :comment,label: "Comentário" %>
+</div>
+<div class="d-flex d-flex justify-content-center">
+    <%= f.submit "Criar endereço", class: "btn btn-success" %>
+</div>
 <% end %>

--- a/app/views/fabric_to_carts/_delivery_points_grid.html.erb
+++ b/app/views/fabric_to_carts/_delivery_points_grid.html.erb
@@ -13,7 +13,7 @@
 
 			<h3><%= delivery_point.name %></h3>
 			<div class="card-details">
-				<p>Endereço: <%= delivery_point.address %></p>
+				<p>Endereço: <%= delivery_point.cidade %> - <%= delivery_point.uf %>, <%= delivery_point.bairro %>, <%= delivery_point.rua %>, <%= delivery_point.numero %>, <%= delivery_point.complemento %></p>
 				<p>CEP: <%= delivery_point.cep %></p>
 				<p>Contato: <%= delivery_point.contact %></p>
 				<p>Comentário: <%= delivery_point.comment %></p>

--- a/db/migrate/20200603120939_remove_address_from_delivery_point.rb
+++ b/db/migrate/20200603120939_remove_address_from_delivery_point.rb
@@ -1,0 +1,5 @@
+class RemoveAddressFromDeliveryPoint < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :delivery_points, :address, :string
+  end
+end

--- a/db/migrate/20200603121020_add_addres_details_to_delivery_point.rb
+++ b/db/migrate/20200603121020_add_addres_details_to_delivery_point.rb
@@ -1,0 +1,10 @@
+class AddAddresDetailsToDeliveryPoint < ActiveRecord::Migration[6.0]
+  def change
+    add_column :delivery_points, :uf, :string
+    add_column :delivery_points, :cidade, :string
+    add_column :delivery_points, :bairro, :string
+    add_column :delivery_points, :rua, :string
+    add_column :delivery_points, :numero, :string
+    add_column :delivery_points, :complemento, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_02_232822) do
+ActiveRecord::Schema.define(version: 2020_06_03_121020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 2020_06_02_232822) do
 
   create_table "delivery_points", force: :cascade do |t|
     t.string "name"
-    t.string "address"
     t.string "cep"
     t.string "contact"
     t.text "comment"
@@ -74,6 +73,12 @@ ActiveRecord::Schema.define(version: 2020_06_02_232822) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "uf"
+    t.string "cidade"
+    t.string "bairro"
+    t.string "rua"
+    t.string "numero"
+    t.string "complemento"
     t.index ["user_id"], name: "index_delivery_points_on_user_id"
   end
 


### PR DESCRIPTION
@aurelien-jacomy @gabantonini 


- delivery point controller 
- unificando ids dos dois forms pra reutilizar a mesma funçao JS
- 'fix' no form de delivery point new, pra apresentar os inputs lado a lado
- fix no show de delivery point pra apresentar os novos endereços
- migration pra adicionar os campos, e deletar o address