### PR TITLE
Bug edit profile fixed

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,7 +10,7 @@
       <% if current_user.photo.attached? %>
         <%= cl_image_tag current_user.photo.key, alt: "#{current_user.name} photo", class: "avatar-large" %>
       <% else %>
-        <%= image_tag "user_green", alt: "alttext", class: "avatar-large" %>  
+        <%= image_tag "user_green.png", alt: "alttext", class: "avatar-large" %>  
       <% end %>
       
       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>


### PR DESCRIPTION
Era um bug apenas no heroku. 
Não sei porque, o image_tag aceito o nome do arquivo sem extensão, mas não o heroku. Aconteceu várias vezes !
