### PR TITLE
Fixed sample price in cart and Stripe

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,20 +25,19 @@ class OrdersController < ApplicationController
 				
 				fabric = f_to_c.fabric
 				if f_to_c.is_sample
-					
-				FabricToOrder.create(
-					order: order,
-					fabric: fabric,
-					fabric_sku: fabric.id,
-					price: fabric.price,
-					quantity: f_to_c.quantity
-					)
-				else
 					FabricToOrder.create(
 						order: order,
 						fabric: fabric,
 						fabric_sku: fabric.id,
 						price: fabric.sample_price,
+						quantity: f_to_c.quantity
+						)
+				else
+					FabricToOrder.create(
+						order: order,
+						fabric: fabric,
+						fabric_sku: fabric.id,
+						price: fabric.price,
 						quantity: f_to_c.quantity
 						)
 				end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -5,8 +5,8 @@ class PaymentsController < ApplicationController
 		
 		cart.each do |ftc| 
 			line_items <<	{
-	      name: ftc.fabric.name,
-	      amount: ftc.fabric.price,
+	      name: "#{ftc.fabric.name} #{"sample" if ftc.is_sample}",
+	      amount: ftc.is_sample ? ftc.fabric.sample_price : ftc.fabric.price,
 	      currency: 'brl',
 	      quantity: ftc.quantity
 	    }

--- a/app/models/fabric_to_cart.rb
+++ b/app/models/fabric_to_cart.rb
@@ -11,9 +11,18 @@ class FabricToCart < ApplicationRecord
   def self.total_price(fabric_to_carts)
   	sum = 0
   	fabric_to_carts.each do |fabric_to_cart|
-  		sum += fabric_to_cart.quantity * fabric_to_cart.fabric.price
+  		sum += fabric_to_cart.quantity * fabric_to_cart.fabric.price unless fabric_to_cart.is_sample
   	end
   	return sum
+  end
+
+  def self.total_sample_price(user)
+    sum = 0
+    fabric_to_carts = FabricToCart.where(user: user).where(is_sample: true)
+    fabric_to_carts.each do |fabric_to_cart|
+      sum += fabric_to_cart.quantity * fabric_to_cart.fabric.sample_price
+    end
+    return sum
   end
 
   def price

--- a/app/views/fabric_to_carts/_samples.html.erb
+++ b/app/views/fabric_to_carts/_samples.html.erb
@@ -16,7 +16,7 @@
             <div class="col-11">
                 <div class="card-product">
                     <% if sample.fabric.photos.attached? %>
-                        <%= cl_image_tag sample.fabric.photos[0].key, alt: "textile picture", class: "avatar", height: 50, width: 50, crop: :scale %>
+                        <%= cl_image_tag sample.fabric.photos[0].key, alt: "textile picture" %>
                     <% else %>
                         <%= image_tag "textile_roll", alt: "undefined textile" %>
                     <% end %>
@@ -26,8 +26,12 @@
                             <p><%= sample.fabric.company.name %></p>
                         </div>
                         <div class="card-options">
-                            <p>R$
-                                <%= sample.sample_price %>,00 
+                            <p><%= number_to_currency(
+                                    sample.sample_price.fdiv(100),
+                                    unit: 'R$',
+                                    separator: ",",
+                                    delimiter: ".",
+                                    format: "%u %n") %>
                             </p>
 
                             <%= link_to sample, method: :delete, data: {confirm: "Deseja apagar esse item?"} do  %>

--- a/app/views/fabric_to_carts/_samples.html.erb
+++ b/app/views/fabric_to_carts/_samples.html.erb
@@ -1,37 +1,42 @@
 <div class="wrapp-supplier">
-<h3 class="amostras-title">Amostras</h3>
- <% @samples.each do |sample| %>
- <div class="row justify-content-end">
-     <div class="col-11">
-         <div class="card-product">
-             <% if sample.fabric.photos.attached? %>
-             <%= cl_image_tag sample.fabric.photos[0].key, alt: "textile picture" %>
-             <% else %>
-             <%= image_tag "textile_roll", alt: "undefined textile" %>
-             <% end %>
-             <div class="card-product-infos">
-                 <div>
-                     <h3><%= sample.fabric.name %></h3>
-                      <p><%= sample.fabric.company.name %></p>
+    <div class="d-flex justify-content-between align-items-center header">
+        <h2 class="amostras-title">Amostras</h3>
+        <p><%= number_to_currency(
+                FabricToCart.total_sample_price(current_user).fdiv(100),
+                unit: 'R$',
+                separator: ",",
+                delimiter: ".",
+                format: "%u %n")
+            %>
+        </p>
+    </div>
+    <hr>
+    <% @samples.each do |sample| %>
+        <div class="row justify-content-end">
+            <div class="col-11">
+                <div class="card-product">
+                    <% if sample.fabric.photos.attached? %>
+                        <%= cl_image_tag sample.fabric.photos[0].key, alt: "textile picture", class: "avatar", height: 50, width: 50, crop: :scale %>
+                    <% else %>
+                        <%= image_tag "textile_roll", alt: "undefined textile" %>
+                    <% end %>
+                    <div class="card-product-infos">
+                        <div>
+                            <h3><%= sample.fabric.name %></h3>
+                            <p><%= sample.fabric.company.name %></p>
+                        </div>
+                        <div class="card-options">
+                            <p>R$
+                                <%= sample.sample_price %>,00 
+                            </p>
 
-                     <% unless sample.delivery_point.nil? %>
-                     
-                     <% end %>
-                 </div>
-                 <div class="card-options">
-                     <p>R$
-                          <%= sample.sample_price %>,00 
-                     </p>
-
-
-
-                     <%= link_to sample, method: :delete, data: {confirm: "Deseja apagar esse item?"} do  %>
-                     <i class="fas fa-trash mx-2"></i>
-                     <% end %>
-                 </div>
-             </div>
-         </div>
-     </div>
- </div>
- <%end%>
+                            <%= link_to sample, method: :delete, data: {confirm: "Deseja apagar esse item?"} do  %>
+                                <i class="fas fa-trash mx-2"></i>
+                            <% end %>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <%end%>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -705,7 +705,7 @@ puts "------------"
 
 (Fabric.first.id..Fabric.last.id).each_with_index do |index|
 	fabric = Fabric.find(index)
-	fabric.sample_price = rand(5..10)
+	fabric.sample_price = rand(5..10)*100
 	fabric.save!
 end
 


### PR DESCRIPTION
Resolvi o problema do valor do cart com o samples: 

- O valor do fornecedor tira agora a quantidade de samples
- Coloquei os valores de samples em centavos em vez de R$, como para o tecido normal. Corrigi o seed mas não rodei, então aparece 0,10 por enquanto. 
- Fiz um total para o valor dos samples do cart

<img width="967" alt="image" src="https://user-images.githubusercontent.com/59183046/84839568-a2db5c00-b03d-11ea-8ce8-cb3cf1cf1e57.png">

Anda da problema no momento de validar o carrinho, porque no modelo de order não tem o conceito de "sample". A quantidade fica de 1m por sample então, e não teria como saber o que é sample ou não. Mas vamos deixar para là ahaha 

<img width="967" alt="image" src="https://user-images.githubusercontent.com/59183046/84839626-d0c0a080-b03d-11ea-8e4a-c0239268cea2.png">

No stripe o valor sai certo
<img width="967" alt="image" src="https://user-images.githubusercontent.com/59183046/84839720-06fe2000-b03e-11ea-9101-b6a4ba8cfd80.png">


